### PR TITLE
Change link to (defunct) portsmon to link to cgit at the revision of …

### DIFF
--- a/templates/build.html
+++ b/templates/build.html
@@ -78,7 +78,7 @@
       {% for origin in ports.new[stat] -%}
         <tr>
           <td>{{ ports.pkgnames[origin] }}</td>
-          <td>{{ pkgstatus.linkorigin(origin) }}</td>
+          <td>{{ pkgstatus.linkorigin(origin, build) }}</td>
           {% if stat == "failed" -%}
           <td>{{ ports[stat][origin].phase }}</td>
           <td></td>

--- a/templates/pkgstatus.html
+++ b/templates/pkgstatus.html
@@ -89,6 +89,6 @@ href="http://{{ servers[build.server].host }}/build.html?mastername={{ build.mas
 ><span class="glyphicon glyphicon-file"></span>{{ text }}</a>
 {%- endmacro %}
 
-{% macro linkorigin(origin) -%}
-<a target="_new" data-toggle="tooltip" title="Portsmon for {{ origin }}" href="http://portsmon.freebsd.org/portoverview.py?category={{ origin.split('/')[0] }}&amp;portname={{ origin.split('/')[1] }}"><span class="glyphicon glyphicon-tasks"></span>{{ origin }}</a>
+{% macro linkorigin(origin, build) -%}
+<a target="_new" data-toggle="tooltip" title="Port skeleton of {{ origin }}@{{ build.buildname }}" href="https://cgit.freebsd.org/ports/tree/{{ origin }}?id={{ build.buildname }}"><span class="glyphicon glyphicon-tasks"></span>{{ origin }}</a>
 {%- endmacro %}


### PR DESCRIPTION
…the build.

Poudriere changed this to point to freshports a while ago, but cgit might
be more useful for pkg-status. Untested.

If not, here is the corresponding fix in poudriere:
https://github.com/freebsd/poudriere/commit/1c07c9b3a3